### PR TITLE
fix dependency cycle if $manage_java=false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class artifactory(
 
   $service_name = 'artifactory'
 
-  if($manage_java) {
+  if ($manage_java) {
     # Ensure other open-jdk packages are removed
     $remove_jdks = [
       'java-1.6.0-openjdk-devel',
@@ -40,14 +40,20 @@ class artifactory(
       version => latest,
       package => 'java-1.8.0-openjdk-devel',
     }
+
+    Class['::java']
+    -> class{'::artifactory::yum': }
+    -> class{'::artifactory::install': }
+    -> class{'::artifactory::config': }
+    ~> class{'::artifactory::service': }
+
+    # Make sure java is included
+    include ::java
+  } else {
+    Class{'::artifactory::yum': }
+    -> class{'::artifactory::install': }
+    -> class{'::artifactory::config': }
+    ~> class{'::artifactory::service': }
   }
 
-  Class['::java']
-  -> class{'::artifactory::yum': }
-  -> class{'::artifactory::install': }
-  -> class{'::artifactory::config': }
-  ~> class{'::artifactory::service': }
-
-  # Make sure java is included
-  include ::java
 }


### PR DESCRIPTION
Currently, setting `$manage_java` to `false` leads to a dependency cycle:

```
Info: Applying configuration version '1508330003'
Error: Found 1 dependency cycle:
(Anchor[java::end] => Class[Java] => Class[Artifactory::Yum] => Yumrepo[bintray-jfrog-artifactory-rpms] => Package[java] => Class[Java])
Try the '--graph' option and opening the resulting '.dot' file in OmniGraffle or GraphViz
Error: Failed to apply catalog: One or more resource dependency cycles detected in graph
```

This patch changes the module to completely ignore the `::java` class in this case.
