### PR TITLE
add support for the embedded derby database

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,13 +5,11 @@
 class artifactory::config {
   # Install storage.properties if Available
   if(
-    $::artifactory::jdbc_driver_url or
     $::artifactory::db_url or
     $::artifactory::db_username or
     $::artifactory::db_password or
     $::artifactory::db_type) {
-    if ($::artifactory::jdbc_driver_url and
-        $::artifactory::db_url and
+    if ($::artifactory::db_url and
         $::artifactory::db_username and
         $::artifactory::db_password and
         $::artifactory::db_type
@@ -41,12 +39,14 @@ class artifactory::config {
         target => "${::artifactory::artifactory_home}/etc/db.properties",
       }
 
-      $file_name =  regsubst($::artifactory::jdbc_driver_url, '.+\/([^\/]+)$', '\1')
+      if ($::artifactory::jdbc_driver_url) {
+        $file_name =  regsubst($::artifactory::jdbc_driver_url, '.+\/([^\/]+)$', '\1')
 
-      file { "${::artifactory::artifactory_home}/tomcat/lib/${file_name}":
-        source => $::artifactory::jdbc_driver_url,
-        mode   => '0775',
-        owner  => 'artifactory',
+        file { "${::artifactory::artifactory_home}/tomcat/lib/${file_name}":
+          source => $::artifactory::jdbc_driver_url,
+          mode   => '0775',
+          owner  => 'artifactory',
+        }
       }
     }
     else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,22 +3,22 @@
 #
 #
 class artifactory(
-  Boolean $manage_java                                                    = true,
-  Boolean $manage_repo                                                    = true,
-  String $yum_name                                                        = 'bintray-jfrog-artifactory-rpms',
-  String $yum_baseurl                                                     = 'http://jfrog.bintray.com/artifactory-rpms',
-  String $package_name                                                    = 'jfrog-artifactory-oss',
-  Optional[String] $jdbc_driver_url                                       = undef,
-  Optional[Enum['mssql', 'mysql', 'oracle', 'postgresql']] $db_type       = undef,
-  Optional[String] $db_url                                                = undef,
-  Optional[String] $db_username                                           = undef,
-  Optional[String] $db_password                                           = undef,
-  Optional[Enum['filesystem', 'fullDb','cachedFS']] $binary_provider_type = undef,
-  Optional[Integer] $pool_max_active                                      = undef,
-  Optional[Integer] $pool_max_idle                                        = undef,
-  Optional[Integer] $binary_provider_cache_maxsize                        = undef,
-  Optional[String] $binary_provider_filesystem_dir                        = undef,
-  Optional[String] $binary_provider_cache_dir                             = undef,
+  Boolean $manage_java                                                       = true,
+  Boolean $manage_repo                                                       = true,
+  String $yum_name                                                           = 'bintray-jfrog-artifactory-rpms',
+  String $yum_baseurl                                                        = 'http://jfrog.bintray.com/artifactory-rpms',
+  String $package_name                                                       = 'jfrog-artifactory-oss',
+  Optional[String] $jdbc_driver_url                                          = undef,
+  Optional[Enum['derby', 'mssql', 'mysql', 'oracle', 'postgresql']] $db_type = undef,
+  Optional[String] $db_url                                                   = undef,
+  Optional[String] $db_username                                              = undef,
+  Optional[String] $db_password                                              = undef,
+  Optional[Enum['filesystem', 'fullDb','cachedFS']] $binary_provider_type    = undef,
+  Optional[Integer] $pool_max_active                                         = undef,
+  Optional[Integer] $pool_max_idle                                           = undef,
+  Optional[Integer] $binary_provider_cache_maxsize                           = undef,
+  Optional[String] $binary_provider_filesystem_dir                           = undef,
+  Optional[String] $binary_provider_cache_dir                                = undef,
 ) {
   $artifactory_home = '/var/opt/jfrog/artifactory'
 

--- a/templates/db.properties.epp
+++ b/templates/db.properties.epp
@@ -1,16 +1,17 @@
-<%- | Enum['mssql', 'mysql', 'oracle', 'postgresql'] $db_type,
-      String                                         $db_url,
-      String                                         $db_username,
-      String                                         $db_password,
-      Enum['filesystem', 'fullDb','cachedFS']        $binary_provider_type           = 'filesystem',
-      Optional[Integer]                              $pool_max_active                = undef,
-      Optional[Integer]                              $pool_max_idle                  = undef,
-      Optional[Integer]                              $binary_provider_cache_maxsize  = undef,
-      Optional[String]                               $binary_provider_filesystem_dir = undef,
-      Optional[String]                               $binary_provider_cache_dir      = undef
+<%- | Enum['derby', 'mssql', 'mysql', 'oracle', 'postgresql'] $db_type,
+      String                                                  $db_url,
+      String                                                  $db_username,
+      String                                                  $db_password,
+      Enum['filesystem', 'fullDb','cachedFS']                 $binary_provider_type           = 'filesystem',
+      Optional[Integer]                                       $pool_max_active                = undef,
+      Optional[Integer]                                       $pool_max_idle                  = undef,
+      Optional[Integer]                                       $binary_provider_cache_maxsize  = undef,
+      Optional[String]                                        $binary_provider_filesystem_dir = undef,
+      Optional[String]                                        $binary_provider_cache_dir      = undef
 | -%>
 <%-
 $db_driver = $db_type ? {
+    'derby'      => 'org.apache.derby.jdbc.EmbeddedDriver',
     'mssql'      => 'com.microsoft.sqlserver.jdbc.SQLServerDriver',
     'mysql'      => 'com.mysql.jdbc.Driver',
     'oracle'     => 'oracle.jdbc.OracleDriver',
@@ -41,8 +42,10 @@ $db_driver = $db_type ? {
 type=<%= $db_type %>
 driver=<%= $db_driver %>
 url=<%= $db_url %>
+<% if $db_type != 'derby' { -%>
 username=<%= $db_username %>
 password=<%= $db_password %>
+<% } -%>
 
 ## Determines where the actual artifacts binaries are stored. Available options:
 ## filesystem - binaries are stored in the filesystem (recommended, default)


### PR DESCRIPTION
This allows everyone to use the embedded derby database, which is suitable for small/test deployments.

The `$db_username` and `$db_password` parameters are optional in this case. I did not add another if-clause, so they need to be set to _something_ for it to work. Tell me if you like me to change this too (personally, I'd prefer another if-clause to allow these parameters to be `undef` for the derby db type).