### PR TITLE
Make artifactory version configurable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,6 +100,13 @@ Sets the package name to install. Defaults to 'jfrog-artifactory-oss'.
 
 This can be changed if Artifactory needs to install a differently named package. Possibly needed if na organization creates their own Artifactory package.
 
+##### `package_version`
+
+Sets the package version to. Defaults to 'present'.
+
+This can be changed if you need to install a specific version. It takes the same values allowed for the `ensure` parameter of the standard `package` resource type.
+
+
 ##### `manage_java`
 
 Tells the module whether or not to manage the java class. This defaults to true. Usually this is what you want.
@@ -111,12 +118,6 @@ If your organization actively manages the java installs across your environment 
 Sets the location for the jdbc driver. The built-in `file` type is used to retrieve the driver.
 
 This is required if using a new data source.
-
-##### `package_name`
-
-Sets the package name to install. Defaults to 'jfrog-artifactory-oss'.
-
-This can be changed if Artifactory needs to install a differently named package. Possibly needed if na organization creates their own Artifactory package.
 
 ##### `db_type`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class artifactory(
   String $yum_name                                                           = 'bintray-jfrog-artifactory-rpms',
   String $yum_baseurl                                                        = 'http://jfrog.bintray.com/artifactory-rpms',
   String $package_name                                                       = 'jfrog-artifactory-oss',
+  String $package_version                                                    = 'present',
   Optional[String] $jdbc_driver_url                                          = undef,
   Optional[Enum['derby', 'mssql', 'mysql', 'oracle', 'postgresql']] $db_type = undef,
   Optional[String] $db_url                                                   = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,6 +4,6 @@
 #
 class artifactory::install {
   package { $::artifactory::package_name:
-    ensure  => present,
+    ensure  => $::artifactory::package_version,
   }
 }

--- a/spec/classes/artifactory_spec.rb
+++ b/spec/classes/artifactory_spec.rb
@@ -78,6 +78,21 @@ describe 'artifactory' do
 
           it { is_expected.to compile.with_all_deps }
         end
+
+        context 'artifactory class with version specified' do
+          let(:params) do
+            {
+              'package_version' => '5.9.1',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_package('jfrog-artifactory-oss').with(
+              'ensure' => '5.9.1',
+            )
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
* Made the version of artifactory to be installed configurable by adding a new parameter which is then passed to the `package` provider. 

* Added a test covering this new case.

* Added documentation on new parameter to `README.markdown` (and removed duplicate `package_name` text)