### PR TITLE
Add db_encrypted_password parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -135,6 +135,11 @@ Only required for database configuration. The username for the database account.
 
 Only required for database configuration. The password for the database account.
 
+##### `db_encrypted_password`
+
+The artifactory encrypted form of db\_password.  On startup, newer versions of artifactory use a 'master key' to encrypt the db\_password in the db.properties file and rewrite the file.
+After you have installed artifactory (and you know the encrypted form), set this value to stop puppet restarting artifactory every 30 minutes.
+
 ##### `binary_provider_type`
 
 Optional setting for the binary storage provider. The type of database to configure for. Valid values are 'filesystem', 'fullDb', 'cachedFS', 'S3'. Defaults to 'filesystem'.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,7 @@ class artifactory::config {
             db_url                         => $::artifactory::db_url,
             db_username                    => $::artifactory::db_username,
             db_password                    => $::artifactory::db_password,
+            db_encrypted_password          => $::artifactory::db_encrypted_password,
             db_type                        => $::artifactory::db_type,
             binary_provider_type           => $::artifactory::binary_provider_type,
             pool_max_active                => $::artifactory::pool_max_active,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class artifactory(
   Optional[String] $db_url                                                   = undef,
   Optional[String] $db_username                                              = undef,
   Optional[String] $db_password                                              = undef,
+  Optional[String] $db_encrypted_password                                    = undef,
   Optional[Enum['filesystem', 'fullDb','cachedFS']] $binary_provider_type    = undef,
   Optional[Integer] $pool_max_active                                         = undef,
   Optional[Integer] $pool_max_idle                                           = undef,

--- a/spec/classes/artifactory_spec.rb
+++ b/spec/classes/artifactory_spec.rb
@@ -57,7 +57,8 @@ describe 'artifactory' do
 
           it {
             is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/db.properties').with(
-              'ensure' => 'file',
+              'ensure'  => 'file',
+              'content' => %r{^password=password$},
             )
           }
 
@@ -67,6 +68,26 @@ describe 'artifactory' do
               'target' => '/var/opt/jfrog/artifactory/etc/db.properties',
             )
           }
+        end
+
+        context 'artifactory class with db_encrypted_password set' do
+          let(:params) do
+            {
+              'jdbc_driver_url'       => 'puppet:///modules/my_module/mysql.jar',
+              'db_url'                => 'oracle://some_url',
+              'db_username'           => 'username',
+              'db_password'           => 'password',
+              'db_encrypted_password' => 'encrypted_password',
+              'db_type'               => 'oracle',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/db.properties').with_content(
+              %r{^password=encrypted_password$},
+            )
+          end
         end
 
         context 'artifactory class with manage_java set to false' do

--- a/templates/db.properties.epp
+++ b/templates/db.properties.epp
@@ -2,6 +2,7 @@
       String                                                  $db_url,
       String                                                  $db_username,
       String                                                  $db_password,
+      Optional[String]                                        $db_encrypted_password          = undef,
       Enum['filesystem', 'fullDb','cachedFS']                 $binary_provider_type           = 'filesystem',
       Optional[Integer]                                       $pool_max_active                = undef,
       Optional[Integer]                                       $pool_max_idle                  = undef,
@@ -44,7 +45,11 @@ driver=<%= $db_driver %>
 url=<%= $db_url %>
 <% if $db_type != 'derby' { -%>
 username=<%= $db_username %>
+<% if $db_encrypted_password { -%>
+password=<%= $db_encrypted_password %>
+<% } else { -%>
 password=<%= $db_password %>
+<% } -%>
 <% } -%>
 
 ## Determines where the actual artifacts binaries are stored. Available options:


### PR DESCRIPTION
Unfortunately, newer versions of Artifactory will modify db.properties
on startup if it finds a non artifactory-encrypted database password.
There doesn't appear to be a way to supress this behaviour.  When puppet
next runs, it sees the config file has changed, puts it back and
restarts artifactory.  Artifactory then reencrypts the value and this
repeats every puppet run.

This commit adds an optional new `db_encrypted_password` parameter.  If
this is set, it will be used instead of `db_password`.  This is far from
perfect, but I couldn't think of a sane way of automatically calculating
`db_encrypted_password` from `db_password`.  I could probably work out
how the encryption is done *and* write a puppet function, but we'd
either need to also add a `master_key` parameter (and overwriting the
artifactory generated one is probably a *bad* idea as its used to
encrypt other passwords), or collect the current `master_key` as a fact
(which probably isn't a great idea either).

Fixes #10