### PR TITLE
Bump dep to allow puppetlabs java <= 4.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-java",
-      "version_requirement": ">= 1.5.0 <= 3.0.0"
+      "version_requirement": ">= 1.5.0 <= 4.0.0"
     },
     {
       "name": "puppetlabs-stdlib",


### PR DESCRIPTION
puppetlabs-java 3.x deprecates OSes that are not supported by this
module (nor are they supported by Java anymore). See https://forge.puppet.com/puppetlabs/java/changelog

I have tested the module in conjunction with `puppetlabs-stdlib` 3.3.0
and not had any issues.

Unit tests pass fine. I was not able to run `pdk validate` as it ran into a ruby error, but running metadata linting by hand worked, so I don't think this PR caused the issues.