### PR TITLE
Configure binary store even if no DB params set

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,8 @@
 fixtures:
   forge_modules:
-    stdlib:      "puppetlabs/stdlib"
-    java:        "puppetlabs/java"
-    wget:        "puppet/wget"
+    stdlib:       "puppetlabs/stdlib"
+    java:         "puppetlabs/java"
+    wget:         "puppet/wget"
+    yumrepo_core: "puppetlabs/yumrepo_core"
   symlinks:
     artifactory: "#{source_dir}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Beaker fires up a new virtual machine (using Vagrant) and runs a series of
 simple tests against it after applying the module. You can run our
 Beaker tests with:
 
-    bundle exec rake acceptance
+    bundle exec rake beaker
 
 This will use the host described in `spec/acceptance/nodeset/default.yml`
 by default. To run against another host, set the `BEAKER_set` environment

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,19 +41,6 @@ class artifactory::config {
         ensure => link,
         target => "${::artifactory::artifactory_home}/etc/db.properties",
       }
-      file { "${::artifactory::artifactory_home}/etc/binarystore.xml":
-        ensure  => file,
-        content => epp(
-          'artifactory/binarystore.xml.epp',
-          {
-            binary_provider_type           => $::artifactory::binary_provider_type,
-            binary_provider_cache_maxsize  => $::artifactory::binary_provider_cache_maxsize,
-            binary_provider_base_data_dir  => $::artifactory::binary_provider_base_data_dir,
-            binary_provider_filesystem_dir => $::artifactory::binary_provider_filesystem_dir,
-            binary_provider_cache_dir      => $::artifactory::binary_provider_cache_dir,
-          }
-        ),
-      }
 
       if ($::artifactory::jdbc_driver_url) {
         $file_name =  regsubst($::artifactory::jdbc_driver_url, '.+\/([^\/]+)$', '\1')
@@ -66,7 +53,21 @@ class artifactory::config {
       }
     }
     else {
-      warning('Database port, hostname, username, password and type must be all be set, or not set. Install proceeding without storage.')
+      warning('Database port, hostname, username, password and type must be all be set, or not set. Install proceeding without DB configuration.')
     }
+  }
+
+  file { "${::artifactory::artifactory_home}/etc/binarystore.xml":
+    ensure  => file,
+    content => epp(
+      'artifactory/binarystore.xml.epp',
+      {
+        binary_provider_type           => $::artifactory::binary_provider_type,
+        binary_provider_cache_maxsize  => $::artifactory::binary_provider_cache_maxsize,
+        binary_provider_base_data_dir  => $::artifactory::binary_provider_base_data_dir,
+        binary_provider_filesystem_dir => $::artifactory::binary_provider_filesystem_dir,
+        binary_provider_cache_dir      => $::artifactory::binary_provider_cache_dir,
+      }
+    ),
   }
 }


### PR DESCRIPTION
This is necessary if users want to use the built-in DB (derby) while
still configuring the filestore to something that does not use the DB,
e.g. `cachedFS`.

Additionally, fix unit tests on puppet 6 by including the yumrepo module

Signed-off-by: Alexander Hermes <alexander.hermes@grasshopperasia.com>