### PR TITLE
Save the database properties in a temporary location.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,14 @@ class artifactory::config {
         $::artifactory::db_password and
         $::artifactory::db_type
         ) {
-      file { "${::artifactory::artifactory_home}/etc/db.properties":
+
+      file { "${::artifactory::artifactory_home}/etc/.secrets":
+        ensure => directory,
+        owner  => 'artifactory',
+        group  => 'artifactory',
+      }
+
+      file { "${::artifactory::artifactory_home}/etc/.secrets/.temp.db.properties":
         ensure  => file,
         content => epp(
           'artifactory/db.properties.epp',

--- a/spec/classes/artifactory_spec.rb
+++ b/spec/classes/artifactory_spec.rb
@@ -56,7 +56,7 @@ describe 'artifactory' do
           }
 
           it {
-            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/db.properties').with(
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/.secrets/.temp.db.properties').with(
               'ensure' => 'file',
               'mode' => '0640',
               'owner' => 'artifactory',


### PR DESCRIPTION
Artifactory 6.6+ allows you to pre-load secrets from a temporary file when starting up Artifactory. Populating the temp file instead of $ARTIFACTORY_HOME/etc/db.properties should prevent puppet and artifactory from fighting over the file (since artifactory will attempt to encrypt/decrypt the
database password on starting up/shutting down).

https://github.com/autostructure/artifactory/issues/10