### PR TITLE
Allow specifying the master.key file.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -178,6 +178,10 @@ Optional setting for the artifactory filestore location. If the binary.provider.
 
 Optional setting for the location of the cache. This should be set to your $ARTIFACTORY_HOME directory directly (not on the NFS).
 
+##### `master_key`
+
+Optional setting for the master key that Artifactory uses to connect to the database. If specified, it ensures that if your node terminates, a new one can be spun up that can connect to the same database as before. Otherwise, Artifactory will generate a new master key on first run.
+
 ## Limitations
 
 This module has been tested on:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -69,4 +69,20 @@ class artifactory::config {
       warning('Database port, hostname, username, password and type must be all be set, or not set. Install proceeding without storage.')
     }
   }
+
+  if ($::artifactory::master_key) {
+    file { "${::artifactory::artifactory_home}/etc/security":
+      ensure => directory,
+      owner  => 'artifactory',
+      group  => 'artifactory',
+    }
+
+    file { "${::artifactory::artifactory_home}/etc/security/master.key":
+      ensure  => file,
+      content => $::artifactory::master_key,
+      mode    => '0640',
+      owner   => 'artifactory',
+      group   => 'artifactory',
+    }
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -77,19 +77,20 @@ class artifactory::config {
       }
     ),
   }
-  
-if ($::artifactory::master_key) {
-  file { "${::artifactory::artifactory_home}/etc/security":
-    ensure => directory,
-    owner  => 'artifactory',
-    group  => 'artifactory',
-  }
 
-  file { "${::artifactory::artifactory_home}/etc/security/master.key":
-    ensure  => file,
-    content => $::artifactory::master_key,
-    mode    => '0640',
-    owner   => 'artifactory',
-    group   => 'artifactory',
+  if ($::artifactory::master_key) {
+    file { "${::artifactory::artifactory_home}/etc/security":
+      ensure => directory,
+      owner  => 'artifactory',
+      group  => 'artifactory',
+    }
+
+    file { "${::artifactory::artifactory_home}/etc/security/master.key":
+      ensure  => file,
+      content => $::artifactory::master_key,
+      mode    => '0640',
+      owner   => 'artifactory',
+      group   => 'artifactory',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class artifactory(
   Optional[String] $binary_provider_base_data_dir                                          = undef,
   Optional[String] $binary_provider_filesystem_dir                                         = undef,
   Optional[String] $binary_provider_cache_dir                                              = undef,
+  Optional[String] $master_key                                                             = undef,
 ) {
   $artifactory_home = '/var/opt/jfrog/artifactory'
 

--- a/spec/classes/artifactory_spec.rb
+++ b/spec/classes/artifactory_spec.rb
@@ -34,6 +34,25 @@ describe 'artifactory' do
           }
         end
 
+        context 'artifactory class with master_key parameter' do
+          let(:params) do
+            {
+              'master_key' => 'masterkey',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/var/opt/jfrog/artifactory/etc/security/master.key').with(
+              'content' => 'masterkey',
+              'mode' => '0640',
+              'owner' => 'artifactory',
+              'group' => 'artifactory',
+            )
+          }
+        end
+
         context 'artifactory class with jdbc_driver_url parameter' do
           let(:params) do
             {


### PR DESCRIPTION
If specified, you can provide the master key that Artifactory uses to connect to the database. This ensures that if your node terminates, a new one can be spun up that can connect to the same database as before.