### PR TITLE
Do not restart on every Puppet run

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -77,6 +77,7 @@ class artifactory::config {
         binary_provider_cache_dir      => $::artifactory::binary_provider_cache_dir,
       }
     ),
+    notify  => Class['artifactory::service'],
   }
 
   if ($::artifactory::master_key) {
@@ -92,6 +93,7 @@ class artifactory::config {
       mode    => '0640',
       owner   => 'artifactory',
       group   => 'artifactory',
+      notify  => Class['artifactory::service'],
     }
   }
 
@@ -104,17 +106,20 @@ class artifactory::config {
       path   => '/lib/systemd/system/artifactory.service',
       source => 'puppet:///modules/artifactory/artifactory.service',
       mode   => '0755',
+      notify => Class['artifactory::service'],
     }
     file_line { 'limits':
       ensure => present,
       path   => '/etc/security/limits.conf',
       line   => "artifactory soft nofile 32000 \n artifactory hard nofile 32000",
+      notify => Class['artifactory::service'],
     }
     file { 'artifManage':
       ensure => present,
       path   => '/opt/jfrog/artifactory/bin/artifactoryManage.sh',
       source => 'puppet:///modules/artifactory/artifactoryManage.sh',
       mode   => '0775',
+      notify => Class['artifactory::service'],
     }
     ~> Class['systemd::systemctl::daemon_reload']
     contain ::mysql::server

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,7 +51,7 @@ class artifactory(
     -> class{'::artifactory::yum': }
     -> class{'::artifactory::install': }
     -> class{'::artifactory::config': }
-    ~> class{'::artifactory::service': }
+    -> class{'::artifactory::service': }
 
     # Make sure java is included
     include ::java
@@ -59,6 +59,6 @@ class artifactory(
     Class{'::artifactory::yum': }
     -> class{'::artifactory::install': }
     -> class{'::artifactory::config': }
-    ~> class{'::artifactory::service': }
+    -> class{'::artifactory::service': }
   }
 }


### PR DESCRIPTION
This PR fixes #23.

After applying this PR Puppet does not restart artifactory anymore when `.temp.db.properties` is created/updated:

```
Info: Applying configuration version '1565082393'
Notice: /Stage[main]/Artifactory::Config/File[/var/opt/jfrog/artifactory/etc/.secrets/.temp.db.properties]/ensure: defined content as '{md5}c4baaff1086fe9a8644b86a8f8987afc'
Notice: Applied catalog in 4.80 seconds

```
However, it will still restart artifactory when there are other configuration changes:

```
Info: Applying configuration version '1565082668'
Notice: /Stage[main]/Artifactory::Config/File[/var/opt/jfrog/artifactory/etc/binarystore.xml]/content: 
--- /var/opt/jfrog/artifactory/etc/binarystore.xml	2019-08-06 11:10:43.195139541 +0200
+++ /tmp/puppet-file20190806-60024-q6w6zr	2019-08-06 11:12:23.224693269 +0200
@@ -25,8 +25,6 @@
   ~ If you are not sure of what you are doing, please contact JFrog Support for assistance.
   -->
 
-<!-- test -->
-
 <config version="1">
     <chain template="file-system"/>
     <provider id="file-system" type="file-system">

Notice: /Stage[main]/Artifactory::Config/File[/var/opt/jfrog/artifactory/etc/binarystore.xml]/content: content changed '{md5}e226ee8e6856b768522a4450d634fca7' to '{md5}040ed60bb7216b4537844fae4e69b73c'
Info: /Stage[main]/Artifactory::Config/File[/var/opt/jfrog/artifactory/etc/binarystore.xml]: Scheduling refresh of Class[Artifactory::Service]
Info: Class[Artifactory::Service]: Scheduling refresh of Service[artifactory]
Notice: /Stage[main]/Artifactory::Service/Service[artifactory]: Triggered 'refresh' from 1 event
Notice: Applied catalog in 7.80 seconds
```

